### PR TITLE
Read Replica now supported in Europe with Paris

### DIFF
--- a/howto-read-replica.md
+++ b/howto-read-replica.md
@@ -35,8 +35,6 @@ A read-only replica is set up to replicate all of your data from the leader depl
 
 - Backups are disabled on read-only replicas. Backups are taken only on leader deployments.
 
-- Read replication is not supported into or out of EU Cloud-enabled regions (currently `eu-de`). It is supported within those regions.
-
 - There is a limit of 5 read-only replicas per leader.
 
 - The read-only replica does not participate in leader->follower elections for the leader cluster and failover to the read-only replica is not automated. Promotion of the read-only replica to a full deployment is a manual, user-initiated task.


### PR DESCRIPTION
As Paris is now available, this section should be removed.
```
Read replication is not supported into or out of EU Cloud-enabled regions (currently eu-de). It is supported within those regions.
```
Found on this page https://cloud.ibm.com/docs/databases-for-postgresql?topic=databases-for-postgresql-read-only-replicas#read-only-replicas-consider