### PR TITLE
Fix syntax highlighting in pg_repack how-to

### DIFF
--- a/howto-pg-repack.md
+++ b/howto-pg-repack.md
@@ -64,10 +64,10 @@ ORDER BY extname;
 
 To run pg_repack with your desired options, use the following syntax:
 
-  ```sh
+   ```sh
    pg_repack -k [OPTION]... [DBNAME]
-
    ```
+
    {: pre}
 
 - The -k option tells pg_repack to keep the original table if a problem occurs, allowing for safer operation in critical environments.


### PR DESCRIPTION
### Description

Updated syntax highlighting for pg_repack command usage.

I'm not sure what the `{: pre}` is aiming to do, but the command above was rendering wrongly:

<img width="462" height="284" alt="image" src="https://github.com/user-attachments/assets/27f3c2ad-bd88-4d8c-8862-cdd6090e2664" />



###  Any other comments?

<!-- Add additional information or screenshots that you think we need.-->

---

### For reviewers (This section is only for IBMers)

You can't merge pull requests here.

- If you can incorporate these changes, copy them to your GitHub Enterprise repo. Leave a comment and close the pull request.
- If you can't accept the changes, leave information about why, and close the pull request.

If you don't have permission to close the request, ask for help in the IBM Cloud \#docs Slack channel.
