### PR TITLE
Remove duplicate connection limit details

### DIFF
--- a/learn-performance.md
+++ b/learn-performance.md
@@ -44,8 +44,6 @@ Allocating larger amounts of memory (outside of the shared buffer pool) to your 
 
 {{site.data.keyword.databases-for-postgresql}} sets the maximum number of connections to your PostgreSQL database to **115**. 15 connections are reserved for the superuser to maintain the state and integrity of your database, and 100 connections are available for you and your applications. After the connection limit is reached, any attempts at starting a new connection results in an error. To prevent overwhelming your deployment with connections, use connection pooling, or scale your deployment and increase its connection limit. For more information, see the [Managing PostgreSQL connections](/docs/databases-for-postgresql?topic=databases-for-postgresql-managing-connections) page.
 
-{{site.data.keyword.databases-for-postgresql}} sets the maximum number of connections to your PostgreSQL database to **115**. 15 connections are reserved for the superuser to maintain the state and integrity of your database, and 100 connections are available for you and your applications. After the connection limit is reached, any attempts at starting a new connection results in an error. To prevent overwhelming your deployment with connections, use connection pooling, or scale your deployment and increase its connection limit. For more information, see [Managing PostgreSQL connections](/docs/databases-for-postgresql?topic=databases-for-postgresql-managing-connections).
-
 ## Performance troubleshooting
 {: #performance_troubleshooting}
 


### PR DESCRIPTION
Removed duplicate information about PostgreSQL connection limits.

Thanks for taking the time to contribute to the IBM Cloud docs! After you open your pull request, a maintainer should review it soon.

We don't merge changes directly in this repository because content is not published from here. However, we'll incorporate any changes in our upstream repository so that they're reflected in the docs.

### Description

Duplicated text for connection limit details.

---

### For reviewers (This section is only for IBMers)

You can't merge pull requests here.

- If you can incorporate these changes, copy them to your GitHub Enterprise repo. Leave a comment and close the pull request.
- If you can't accept the changes, leave information about why, and close the pull request.

If you don't have permission to close the request, ask for help in the IBM Cloud \#docs Slack channel.
